### PR TITLE
Copy CSeq even if 0

### DIFF
--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -1794,7 +1794,7 @@ int rtsp_request_header_write(const struct rtsp_request_header *header,
 		   header->uri);
 
 	/* 'CSeq' */
-	if (header->cseq > 0) {
+	if (header->cseq >= 0) {
 		CHECK_FUNC(rtsp_sprintf,
 			   ret,
 			   return ret,


### PR DESCRIPTION
According to the RTSP spec (RFC 7826), the initial sequence
number is recommended to be 0:

"The initial sequence number can be any number; however, it is
RECOMMENDED to start at 0."

The RTSP implementation in GStreamer's gst-plugins-base follows
this recommendation[0], unlike LibVLC which seems to start at 2.
Due to this bug, GStreamer can't be used to process the Anafi's
video stream as it will refuse to parse a response to its
initial OPTIONS request that doesn't include a CSeq header field.

0 = https://github.com/GStreamer/gst-plugins-base/blob/master/gst-libs/gst/rtsp/gstrtspconnection.c#L365